### PR TITLE
Add memo field and integrate memo UI

### DIFF
--- a/app/src/main/java/io/github/hayato2158/lifescore/MainActivity.kt
+++ b/app/src/main/java/io/github/hayato2158/lifescore/MainActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -15,6 +14,7 @@ import io.github.hayato2158.lifescore.data.MonthlySummary // Preview用にMonthl
 import io.github.hayato2158.lifescore.data.ScoreRecord
 import io.github.hayato2158.lifescore.ui.ScoreHomeScreen
 import io.github.hayato2158.lifescore.ui.ScoresViewModel
+import io.github.hayato2158.lifescore.ui.theme.LifeScoreTheme
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -29,14 +29,17 @@ class MainActivity : ComponentActivity() {
             val currentMonthScores by vm.currentMonthScores.collectAsState()
             val formattedYearMonth by vm.formattedYearMonth.collectAsState()
             val monthlySummary by vm.monthlySummary.collectAsState()
+            val currentMemo by vm.currentMemo.collectAsState()
 
-            MaterialTheme {
+            LifeScoreTheme {
                 Surface {
                     ScoreHomeScreen(
                         allScores = allScores,
                         currentMonthScores = currentMonthScores,
                         formattedYearMonth = formattedYearMonth,
                         monthlySummary = monthlySummary,
+                        currentMemo = currentMemo,
+                        onMemoChange = vm::updateMemo,
                         onSave = { score -> vm.saveToday(score) },
                         onPreviousMonth = { vm.changeMonth(-1) },
                         onNextMonth = { vm.changeMonth(1) }
@@ -67,12 +70,14 @@ fun PreviewScoreHome() {
     // ここでは当月のデータだけが含まれるようにしてみます。
     val fakeCurrentMonthScores = fakeAllScores.filter { it.date.startsWith("2025-08") }
 
-    MaterialTheme {
+    LifeScoreTheme {
         ScoreHomeScreen(
             allScores = fakeAllScores,
             currentMonthScores = fakeCurrentMonthScores,
             formattedYearMonth = "2025年08月",
             monthlySummary = MonthlySummary(totalScore = 8, averageScore = 4.0, recordCount = 2), // fakeCurrentMonthScoresに合わせる (5+3=8, count=2)
+            currentMemo = "",
+            onMemoChange = {},
             onSave = {},
             onPreviousMonth = {},
             onNextMonth = {}

--- a/app/src/main/java/io/github/hayato2158/lifescore/data/AppDatabase.kt
+++ b/app/src/main/java/io/github/hayato2158/lifescore/data/AppDatabase.kt
@@ -3,7 +3,7 @@ package io.github.hayato2158.lifescore.data
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [ScoreRecord::class], version = 1)
+@Database(entities = [ScoreRecord::class], version = 2)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun scoreDao(): ScoreDao
 }

--- a/app/src/main/java/io/github/hayato2158/lifescore/data/ScoreRecord.kt
+++ b/app/src/main/java/io/github/hayato2158/lifescore/data/ScoreRecord.kt
@@ -6,5 +6,6 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "score_records")
 data class ScoreRecord(
     @PrimaryKey val date: String,
-    val score: Int
+    val score: Int,
+    val memo: String? = null
 )

--- a/app/src/main/java/io/github/hayato2158/lifescore/data/ScoreRepository.kt
+++ b/app/src/main/java/io/github/hayato2158/lifescore/data/ScoreRepository.kt
@@ -18,9 +18,9 @@ class ScoreRepository @Inject constructor(
 
     fun all(): Flow<List<ScoreRecord>> = scoreDao.observeAll()
 
-    suspend fun saveToday(score: Int) {
+    suspend fun saveToday(score: Int, memo: String?) {
         val today = LocalDate.now(clock).format(DateTimeFormatter.ISO_LOCAL_DATE) // YYYY-MM-DD
-        scoreDao.upsert(ScoreRecord(date = today, score = score))
+        scoreDao.upsert(ScoreRecord(date = today, score = score, memo = memo))
     }
 
     // 新しく追加するメソッド

--- a/app/src/main/java/io/github/hayato2158/lifescore/di/AppModule.kt
+++ b/app/src/main/java/io/github/hayato2158/lifescore/di/AppModule.kt
@@ -23,7 +23,8 @@ object AppModule {
             context.applicationContext,
             AppDatabase::class.java,
             "app.db" // データベース名
-        ).build()
+        ).fallbackToDestructiveMigration()
+            .build()
     }
 
     @Provides

--- a/app/src/main/java/io/github/hayato2158/lifescore/ui/ScoreHomeScreen.kt
+++ b/app/src/main/java/io/github/hayato2158/lifescore/ui/ScoreHomeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -41,6 +42,8 @@ fun ScoreHomeScreen(
     currentMonthScores: List<ScoreRecord>,
     formattedYearMonth: String,
     monthlySummary: MonthlySummary?,
+    currentMemo: String,
+    onMemoChange: (String) -> Unit,
     onSave: (Int) -> Unit,
     onPreviousMonth: () -> Unit,
     onNextMonth: () -> Unit,
@@ -74,6 +77,8 @@ fun ScoreHomeScreen(
 
             // スコア入力ボタンエリア
             ScoreInputButtons(
+                memo = currentMemo,
+                onMemoChange = onMemoChange,
                 onScoreSelected = { score -> onSave(score) },
                 modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp) // 上下に少しパディング
             )
@@ -104,10 +109,19 @@ fun ScoreHomeScreen(
 
 @Composable
 fun ScoreInputButtons(
+    memo: String,
+    onMemoChange: (String) -> Unit,
     onScoreSelected: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        OutlinedTextField(
+            value = memo,
+            onValueChange = onMemoChange,
+            label = { Text("メモ") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(8.dp))
         Text("今日の気分は？", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
         Spacer(modifier = Modifier.height(8.dp))
         Row(
@@ -181,15 +195,23 @@ fun ScoreRecordItem(record: ScoreRecord, modifier: Modifier = Modifier) {
         modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp)
     ) {
-        Row(
+        Column(
             modifier = Modifier
                 .padding(16.dp)
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+                .fillMaxWidth()
         ) {
-            Text(text = record.date, style = MaterialTheme.typography.bodyLarge)
-            Text(text = "${record.score}", style = MaterialTheme.typography.headlineSmall)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(text = record.date, style = MaterialTheme.typography.bodyLarge)
+                Text(text = "${record.score}", style = MaterialTheme.typography.headlineSmall)
+            }
+            if (!record.memo.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(text = record.memo ?: "", style = MaterialTheme.typography.bodyMedium)
+            }
         }
     }
 }

--- a/app/src/main/java/io/github/hayato2158/lifescore/ui/ScoresViewModel.kt
+++ b/app/src/main/java/io/github/hayato2158/lifescore/ui/ScoresViewModel.kt
@@ -29,6 +29,9 @@ class ScoresViewModel @Inject constructor(
     private val _monthlySummary = MutableStateFlow<MonthlySummary?>(null)
     val monthlySummary: StateFlow<MonthlySummary?> = _monthlySummary.asStateFlow()
 
+    private val _currentMemo = MutableStateFlow("")
+    val currentMemo: StateFlow<String> = _currentMemo.asStateFlow()
+
     init {
         Log.d("ScoresViewModel", "ViewModel initialized. Repository instance: $repo")
         // 初期表示月でサマリを読み込む
@@ -60,9 +63,14 @@ class ScoresViewModel @Inject constructor(
             }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
+    fun updateMemo(newMemo: String) {
+        _currentMemo.value = newMemo
+    }
+
     fun saveToday(score: Int) {
         viewModelScope.launch {
-            repo.saveToday(score)
+            repo.saveToday(score, currentMemo.value.ifBlank { null })
+            _currentMemo.value = ""
             loadMonthlySummary(_currentYearMonth.value)
         }
     }


### PR DESCRIPTION
## Summary
- extend score records with optional memo field and upgrade Room database
- expose memo state in ViewModel and display memo input in score screen
- apply LifeScoreTheme and pass memo-related callbacks from MainActivity

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac227788c88328a2a300500cd81262